### PR TITLE
Update color.lua

### DIFF
--- a/utils/color.lua
+++ b/utils/color.lua
@@ -23,7 +23,7 @@ function rgbToHsl(r, g, b, a)
     h, s = 0, 0 -- achromatic
   else
     local d = max - min
-    local s
+    --local s   -- <- FIXED: 's' should not be declared here as local.
     if l > 0.5 then s = d / (2 - max - min) else s = d / (max + min) end
     if max == r then
       h = (g - b) / d


### PR DESCRIPTION
Inside 'rgbToHsl', the variable 's' was mistakenly re-declared as local inside the if/then/else block. This caused the function to return saturation either as '0' (for b/w rgb values) or as 'nil' (for all the other cases).

The statement (line 26) was commented, but it can be permanently removed.
I propose to do so and merge the branch with the master one.